### PR TITLE
Hassan

### DIFF
--- a/Frontend/src/components/css/PostCard.css
+++ b/Frontend/src/components/css/PostCard.css
@@ -6,6 +6,8 @@
   padding: 18px 20px;
   min-height: 180px;
   width: 100%;
+  position: relative;
+  z-index: 60; /* above sticky sidebar (55) when scrolling */
 }
 
 .vote-section {

--- a/Frontend/src/components/css/RightSidebar.css
+++ b/Frontend/src/components/css/RightSidebar.css
@@ -1,12 +1,12 @@
 .right-sidebar {
   position: -webkit-sticky;
   position: sticky;
-  top: 64px;
+  top: 64px; /* stick just below navbar */
   width: 312px;
   background: #f6f7f8;
   padding: 24px 16px 16px 16px;
   border-left: 1px solid #eaeaea;
-  z-index: 6;
+  z-index: 55; /* above filter bar (50) but below navbar */
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/Frontend/src/components/css/RightSidebar.css
+++ b/Frontend/src/components/css/RightSidebar.css
@@ -6,12 +6,12 @@
   background: #f6f7f8;
   padding: 24px 16px 16px 16px;
   border-left: 1px solid #eaeaea;
-  z-index: 55; /* above filter bar (50) but below navbar */
+  z-index: 40; /* below posts (60) so posts appear on top when scrolling */
   display: flex;
   flex-direction: column;
   align-items: center;
 }
-/* ... rest of the file ... */
+
 
 .community-card {
   background: #fff;

--- a/Frontend/src/pages/ExplorePage.css
+++ b/Frontend/src/pages/ExplorePage.css
@@ -6,8 +6,8 @@
   min-height: calc(100vh - 64px);
   padding-top: 0;
   /* Prevent page-level horizontal scrollbar while keeping sticky working */
-  overflow-x: hidden;
-  position: relative;
+  /* remove properties that can break sticky in descendants */
+  position: static;
   color: #1c1c1c;
   /* Ensure the main container doesn't exceed viewport width */
   width: 100%;
@@ -20,8 +20,8 @@
   background: #ffffff;
   border-bottom: 1px solid #ccc;
   position: sticky;
-  top: 0;
-  z-index: 50;
+  top: 64px;
+  z-index: 60;
   margin: 0;
   /* Ensure header stays within container width */
   width: 100%;

--- a/Frontend/src/pages/PopularPage.css
+++ b/Frontend/src/pages/PopularPage.css
@@ -4,7 +4,6 @@
   background: #f6f7f8;
   width: 100%;
   box-sizing: border-box;
-  overflow-x: hidden;
 }
 
 .popular-grid {
@@ -13,16 +12,17 @@
   gap: 24px;
   padding: 24px;
   margin-top: 16px;
-  align-items: start; /* prevent grid stretch that blocks sticky */
+  align-items: stretch; /* stretch rows so sidebar has full height track */
 }
 
 .feed-column {
   min-width: 0;
+  align-self: stretch;
 }
 
 .sidebar-column {
-  /* Container for sticky sidebar */
-  align-self: start; /* required for sticky to work in grid */
+  align-self: stretch;
+  position: relative;
 }
 
 .trending-section {
@@ -81,10 +81,12 @@
   margin-bottom: 24px;
   margin-top: 24px;
   position: sticky;
-  top: 64px; /* stick below fixed navbar */
-  z-index: 50; /* above content and sidebar */
-  background: #f6f7f8; /* match page bg to avoid visual jump */
-  padding: 12px 0; /* space for shadow area when sticking */
+  top: 64px;
+  z-index: 70;
+  background: #f6f7f8;
+  padding: 12px 24px;
+  margin-left: -24px;
+  margin-right: -24px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 
@@ -111,5 +113,5 @@
   gap: 24px;
   width: 100%;
   position: relative;
-  z-index: 7; /* Slightly above sidebar (6) to avoid overlap when needed */
+  z-index: 60; /* posts above sidebar (40) */
 }

--- a/Frontend/src/pages/PopularPage.css
+++ b/Frontend/src/pages/PopularPage.css
@@ -13,6 +13,7 @@
   gap: 24px;
   padding: 24px;
   margin-top: 16px;
+  align-items: start; /* prevent grid stretch that blocks sticky */
 }
 
 .feed-column {
@@ -21,6 +22,7 @@
 
 .sidebar-column {
   /* Container for sticky sidebar */
+  align-self: start; /* required for sticky to work in grid */
 }
 
 .trending-section {


### PR DESCRIPTION
This pull request updates the z-index stacking and sticky positioning for several main layout components, improving the visual layering and sticky behavior of posts, sidebars, and headers across the Explore and Popular pages. The changes ensure that posts and headers correctly appear above sidebars when scrolling, and that sticky elements align with the navbar and container widths. Additionally, some CSS properties that interfered with sticky positioning were removed or adjusted.

**Sticky positioning and z-index fixes:**

* Increased the z-index of `.post-card` and `.explore-page-header` so posts and headers appear above the sidebar when scrolling (`PostCard.css`, `ExplorePage.css`). [[1]](diffhunk://#diff-fae2b2b55ce224c500cf2a64b0ac66f5c3d571107f92f6e8983947bd6d18bc12R9-R10) [[2]](diffhunk://#diff-e52fa430777d3d44de269cf12672a7e67f20ed93bfef542b20f62ca5e16cce98L23-R24)
* Lowered the z-index of `.right-sidebar` to ensure it stays below posts, and clarified comments for sticky positioning (`RightSidebar.css`).
* Updated sticky header and trending section styles on Popular and Explore pages to align below the navbar and adjusted z-index for proper stacking (`PopularPage.css`, `ExplorePage.css`). [[1]](diffhunk://#diff-0fcaf8bc75cd8d10a0e7ab1473fe260e789965e83a715e41ee47389f7b7d6a00L82-R89) [[2]](diffhunk://#diff-e52fa430777d3d44de269cf12672a7e67f20ed93bfef542b20f62ca5e16cce98L23-R24)

**Container and grid layout improvements:**

* Removed or adjusted CSS properties (`overflow-x: hidden`, `position: relative`) from page containers that could interfere with sticky child elements (`ExplorePage.css`, `PopularPage.css`). [[1]](diffhunk://#diff-e52fa430777d3d44de269cf12672a7e67f20ed93bfef542b20f62ca5e16cce98L9-R10) [[2]](diffhunk://#diff-0fcaf8bc75cd8d10a0e7ab1473fe260e789965e83a715e41ee47389f7b7d6a00L7)
* Updated grid and sidebar columns to stretch and use relative positioning for better sidebar and feed alignment (`PopularPage.css`).

**Visual consistency:**

* Adjusted padding, margin, and background for sticky headers and trending sections to ensure they visually align with the rest of the page (`PopularPage.css`).

**Post and feed stacking context:**

* Increased the z-index for the posts container so that posts consistently appear above the sidebar (`PopularPage.css`).