### PR TITLE
Refactor sidebar toggle and update profile layout

### DIFF
--- a/Frontend/src/components/react/Sidebar.jsx
+++ b/Frontend/src/components/react/Sidebar.jsx
@@ -39,7 +39,30 @@ export default function Sidebar({ isSidebarOpen, toggleSidebar }) {
 
   return (
     <>
-      <aside className="sidebar">
+      <button
+        className="sidebar-edge-toggle"
+        aria-label="Toggle sidebar"
+        title="Toggle sidebar"
+        onClick={toggleSidebar}
+        data-sidebar-open={isSidebarOpen}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          aria-hidden="true"
+          className="hamburger-svg"
+        >
+          <path d="M3 5 H17" stroke="#000" strokeWidth="2.5" strokeLinecap="round" />
+          <path d="M3 10 H17" stroke="#000" strokeWidth="2.5" strokeLinecap="round" />
+          <path d="M3 15 H17" stroke="#000" strokeWidth="2.5" strokeLinecap="round" />
+        </svg>
+        <span className="hamburger-fallback" aria-hidden="true" />
+      </button>
+
+      <aside className={`sidebar ${isSidebarOpen ? 'open' : 'collapsed'}`} data-open={isSidebarOpen}>
         <nav className="sidebar-nav">
 
           <Link 
@@ -66,12 +89,9 @@ export default function Sidebar({ isSidebarOpen, toggleSidebar }) {
             Explore
           </Link>
 
-          {/* ----------------------------- */}
-          {/* START A COMMUNITY (OPEN MODAL) */}
-          {/* ----------------------------- */}
           {user && (
             <Link
-              to="#" // we keep it as # because it just opens modal
+              to="#"
               className="sidebar-link start-community-link"
               onClick={() => setOpenModal(true)}
             >
@@ -80,7 +100,6 @@ export default function Sidebar({ isSidebarOpen, toggleSidebar }) {
             </Link>
           )}
 
-          {/* Recents (collapsible like Resources) - only show when logged in */}
           {user && recents && recents.length > 0 && (
             <div className="sidebar-section">
               <button
@@ -108,8 +127,6 @@ export default function Sidebar({ isSidebarOpen, toggleSidebar }) {
             </div>
           )}
 
-
-
           <div className="sidebar-section">
             <button
               className="accordion-btn"
@@ -135,77 +152,7 @@ export default function Sidebar({ isSidebarOpen, toggleSidebar }) {
         </footer>
       </aside>
 
-      {/* Render the modal when openModal is true */}
       {openModal && <CreateCommunityModal onClose={() => setOpenModal(false)} />}
-      <button
-        className="sidebar-edge-toggle"
-        aria-label="Toggle sidebar"
-        title="Toggle sidebar"
-        onClick={toggleSidebar}
-        data-sidebar-open={isSidebarOpen}
-      >
-        {/* SVG hamburger (primary) */}
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          aria-hidden="true"
-          className="hamburger-svg"
-        >
-          <path d="M3 5 H17" stroke="#000" strokeWidth="2.5" strokeLinecap="round" />
-          <path d="M3 10 H17" stroke="#000" strokeWidth="2.5" strokeLinecap="round" />
-          <path d="M3 15 H17" stroke="#000" strokeWidth="2.5" strokeLinecap="round" />
-        </svg>
-        {/* CSS hamburger fallback (in case svg is overridden) */}
-        <span className="hamburger-fallback" aria-hidden="true" />
-      </button>
-      <aside className={`sidebar ${isSidebarOpen ? 'open' : 'collapsed'}`} data-open={isSidebarOpen}>
-        <nav className="sidebar-nav">
-            <Link 
-              to="/" 
-              className={`sidebar-link ${location.pathname === "/" ? "active" : ""}`}
-            >
-              <span className="sidebar-icon home" />
-              Home
-            </Link>
-            <Link 
-              to="/popular" 
-              className={`sidebar-link ${location.pathname === "/popular" ? "active" : ""}`}
-            >
-              <span className="sidebar-icon popular" />
-              Popular
-            </Link>
-            <Link 
-              to="/explore" 
-              className={`sidebar-link ${location.pathname === "/explore" ? "active" : ""}`}
-            >
-              <span className="sidebar-icon explore" />
-              Explore
-            </Link>
-            <div className="sidebar-section">
-              <button
-                className="accordion-btn"
-                onClick={() => setResourcesOpen(!resourcesOpen)}
-              >
-                Resources
-                <span className={`accordion-arrow ${resourcesOpen ? "open" : ""}`} />
-              </button>
-              {resourcesOpen && (
-                <div className="accordion-content">
-                  <a href="#">About Reddit</a>
-                  <a href="#">Advertise</a>
-                  <a href="#">Developer Platform</a>
-                  <a href="#">Help</a>
-                </div>
-              )}
-            </div>
-          </nav>
-          <footer className="sidebar-footer">
-            <a href="#">Privacy</a> · <a href="#">Terms</a> · <a href="#">Contact</a>
-          </footer>
-      </aside>
     </>
   );
 }

--- a/Frontend/src/pages/UserProfilePage.css
+++ b/Frontend/src/pages/UserProfilePage.css
@@ -5,15 +5,13 @@
     font-family: Arial, sans-serif;
   }
   
-  .profile-layout {
-    display: flex;
-    justify-content: center;
-    gap: 24px;
-    padding: 24px;
-    margin-left: 240px; 
-  }
-  
-  .profile-main {
+.profile-layout {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  padding: 24px;
+  margin-left: 0;
+}  .profile-main {
     width: 640px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This pull request refactors the sidebar component in `Sidebar.jsx` to improve its layout and accessibility, and updates the sidebar toggle button placement. It also adjusts the left margin in the user profile page CSS to better accommodate the sidebar changes.

**Sidebar component improvements:**

* Moved the sidebar toggle button (`sidebar-edge-toggle`) above the `<aside>` element for better accessibility and layout, and removed its duplicate instance at the bottom of the component. [[1]](diffhunk://#diff-9611c5feea45beead02e015fa196e399227c4ae005b31bf0f0ac4ba06babbf72L42-R65) [[2]](diffhunk://#diff-9611c5feea45beead02e015fa196e399227c4ae005b31bf0f0ac4ba06babbf72L138-L208)
* Updated the sidebar's open/closed state by toggling CSS classes (`open`/`collapsed`) and using the `data-open` attribute for clearer state management.
* Cleaned up sidebar navigation markup by removing redundant comments and streamlining conditional rendering for user-specific links and sections. [[1]](diffhunk://#diff-9611c5feea45beead02e015fa196e399227c4ae005b31bf0f0ac4ba06babbf72L69-R94) [[2]](diffhunk://#diff-9611c5feea45beead02e015fa196e399227c4ae005b31bf0f0ac4ba06babbf72L83) [[3]](diffhunk://#diff-9611c5feea45beead02e015fa196e399227c4ae005b31bf0f0ac4ba06babbf72L111-L112)

**CSS/layout fixes:**

* Removed the hardcoded left margin from `.profile-layout` in `UserProfilePage.css` to ensure the profile page layout works correctly with the updated sidebar.Moved the sidebar toggle button above the sidebar and improved its accessibility. Updated the sidebar's open/collapsed state handling. Adjusted UserProfilePage layout by removing left margin for better alignment with sidebar changes.